### PR TITLE
Use yarn in CI

### DIFF
--- a/blueprints/zesty-deploy-config/files/circle.yml
+++ b/blueprints/zesty-deploy-config/files/circle.yml
@@ -3,9 +3,13 @@ machine:
     version: 6
 
 dependencies:
-  post:
-    - npm install -g bower
+  override:
+    - npm install -g bower yarn
     - bower install
+    - yarn install
+
+  cache_directories:
+    - ~/.yarn-cache
 
 deployment:
   production:


### PR DESCRIPTION
There's no real blocker for doing this. If a yarn lockfile is present it will be used, otherwise `yarn install` will act like `npm install`. The benefits are that we get deterministic tests and deployments when a lockfile is present. Another bonus is that `yarn install` takes less time than `npm install` which will speed up the CI builds.

There are a couple caveats: yarn doesn't support npm organizations yet, as well as some other niche npm features, but they don't affect us.