### PR TITLE
Don't depend on ember-cli being installed globally

### DIFF
--- a/blueprints/zesty-deploy-config/files/circle.yml
+++ b/blueprints/zesty-deploy-config/files/circle.yml
@@ -15,7 +15,7 @@ deployment:
   production:
     branch: master
     commands:
-      - 'ember deploy production --activate'
+      - yarn run -- ember deploy production --activate
 
   pull-request:
     branch: /^((?!master).)*$/


### PR DESCRIPTION
Instead, just use the local shell script in `node_modules/.bin`. It's basically the equivalent of `bundle exec` for yarn/npm. For example, on my machine I get

```
Nebula:ember-cli-zesty-app-base martin$ yarn run -- ember deploy production --activate
yarn run v0.17.0
$ "/Users/martin/Projects/zesty/ember-cli-zesty-app-base/node_modules/.bin/ember" deploy production --activate
```

Fixes https://circleci.com/gh/zestyzesty/client-calculator/165.