### PR TITLE
Update circleci context

### DIFF
--- a/blueprints/zesty-deploy-config/files/.circleci/config.yml
+++ b/blueprints/zesty-deploy-config/files/.circleci/config.yml
@@ -108,14 +108,14 @@ workflows:
     jobs:
       - build
       - deploy:
-          context: square-slack-engineering-channel
+          context: ember-deploy
           requires:
             - build
           filters:
             branches:
               only: master
       - pull-request-deploy:
-          context: square-slack-engineering-channel
+          context: ember-deploy
           requires:
             - build
           filters:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-cli-deploy-zesty-pack",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "license": "MIT",
   "description": "An opinionated collection of ember-cli-deploy plugins for continuous deployment",
   "repository": "https://github.com/zestyzesty/ember-cli-deploy-zesty-pack.git",


### PR DESCRIPTION
## Description

This PR changes the default CircleCI context to "ember-deploy" .

## Context/Motivation

The previous context was named specifically for the slack environment variables, which would have been confusing when adding in other environment variables to it.